### PR TITLE
feat: add EOF Vim modeline comments for indentation consistency

### DIFF
--- a/lua/spinner.lua
+++ b/lua/spinner.lua
@@ -48,3 +48,4 @@ function M.render(id)
 end
 
 return M
+-- vim: set ts=2 sts=2 sw=2 et ai si sta:

--- a/lua/spinner/cmd.lua
+++ b/lua/spinner/cmd.lua
@@ -90,3 +90,4 @@ function M.setup(engine)
 end
 
 return M
+-- vim: set ts=2 sts=2 sw=2 et ai si sta:

--- a/lua/spinner/config.lua
+++ b/lua/spinner/config.lua
@@ -160,3 +160,4 @@ function M.setup(opts)
 end
 
 return M
+-- vim: set ts=2 sts=2 sw=2 et ai si sta:

--- a/lua/spinner/demo.lua
+++ b/lua/spinner/demo.lua
@@ -87,3 +87,4 @@ function M.open()
 end
 
 return M
+-- vim: set ts=2 sts=2 sw=2 et ai si sta:

--- a/lua/spinner/engine.lua
+++ b/lua/spinner/engine.lua
@@ -131,3 +131,4 @@ end
 
 -- Return the class itself, instantiation happens externally
 return M
+-- vim: set ts=2 sts=2 sw=2 et ai si sta:

--- a/lua/spinner/event.lua
+++ b/lua/spinner/event.lua
@@ -83,3 +83,4 @@ function M.attach(id, event)
 end
 
 return M
+-- vim: set ts=2 sts=2 sw=2 et ai si sta:

--- a/lua/spinner/event/lsp.lua
+++ b/lua/spinner/event/lsp.lua
@@ -80,3 +80,4 @@ function M.request(id, methods, client_names)
 end
 
 return M
+-- vim: set ts=2 sts=2 sw=2 et ai si sta:

--- a/lua/spinner/heap.lua
+++ b/lua/spinner/heap.lua
@@ -125,3 +125,4 @@ function M:clear()
 end
 
 return M
+-- vim: set ts=2 sts=2 sw=2 et ai si sta:

--- a/lua/spinner/pattern.lua
+++ b/lua/spinner/pattern.lua
@@ -1472,3 +1472,4 @@ return {
     },
   },
 }
+-- vim: set ts=2 sts=2 sw=2 et ai si sta:

--- a/lua/spinner/scheduler.lua
+++ b/lua/spinner/scheduler.lua
@@ -153,3 +153,4 @@ function M:schedule(job, at)
 end
 
 return M
+-- vim: set ts=2 sts=2 sw=2 et ai si sta:

--- a/lua/spinner/set.lua
+++ b/lua/spinner/set.lua
@@ -95,3 +95,4 @@ function M:is_empty()
 end
 
 return M
+-- vim: set ts=2 sts=2 sw=2 et ai si sta:

--- a/lua/spinner/state.lua
+++ b/lua/spinner/state.lua
@@ -700,3 +700,4 @@ end
 return {
   new = new,
 }
+-- vim: set ts=2 sts=2 sw=2 et ai si sta:

--- a/lua/spinner/status.lua
+++ b/lua/spinner/status.lua
@@ -8,3 +8,4 @@ local STATUS = {
 }
 
 return STATUS
+-- vim: set ts=2 sts=2 sw=2 et ai si sta:

--- a/lua/spinner/ui.lua
+++ b/lua/spinner/ui.lua
@@ -85,3 +85,4 @@ function M.get_ui_updater(state)
 end
 
 return M
+-- vim: set ts=2 sts=2 sw=2 et ai si sta:

--- a/lua/spinner/ui/cmdline.lua
+++ b/lua/spinner/ui/cmdline.lua
@@ -32,3 +32,4 @@ return function(state)
     )
   end
 end
+-- vim: set ts=2 sts=2 sw=2 et ai si sta:

--- a/lua/spinner/ui/cursor.lua
+++ b/lua/spinner/ui/cursor.lua
@@ -69,3 +69,4 @@ return function(state)
     })
   end
 end
+-- vim: set ts=2 sts=2 sw=2 et ai si sta:

--- a/lua/spinner/ui/extmark.lua
+++ b/lua/spinner/ui/extmark.lua
@@ -83,3 +83,4 @@ return function(state)
     extmark_id = id
   end
 end
+-- vim: set ts=2 sts=2 sw=2 et ai si sta:

--- a/lua/spinner/ui/statusline.lua
+++ b/lua/spinner/ui/statusline.lua
@@ -17,3 +17,4 @@ end
 return function()
   vim.cmd.redrawstatus()
 end
+-- vim: set ts=2 sts=2 sw=2 et ai si sta:

--- a/lua/spinner/ui/tabline.lua
+++ b/lua/spinner/ui/tabline.lua
@@ -17,3 +17,4 @@ end
 return function()
   vim.cmd.redrawtabline()
 end
+-- vim: set ts=2 sts=2 sw=2 et ai si sta:

--- a/lua/spinner/ui/winbar.lua
+++ b/lua/spinner/ui/winbar.lua
@@ -17,3 +17,4 @@ end
 return function()
   vim.cmd.redrawstatus()
 end
+-- vim: set ts=2 sts=2 sw=2 et ai si sta:

--- a/lua/spinner/ui/window_title.lua
+++ b/lua/spinner/ui/window_title.lua
@@ -42,3 +42,4 @@ return function(state, kind)
     vim.api.nvim_win_set_config(win, win_config)
   end
 end
+-- vim: set ts=2 sts=2 sw=2 et ai si sta:

--- a/lua/spinner/utils.lua
+++ b/lua/spinner/utils.lua
@@ -156,3 +156,4 @@ function M.on_win_closed(win, cb)
 end
 
 return M
+-- vim: set ts=2 sts=2 sw=2 et ai si sta:


### PR DESCRIPTION
## Description

I added a [Vim modeline comment](https://neovim.io/doc/user/usr_21.html#_modelines) at the end of each Lua file (only in the `lua/` folder, wasn't sure aboet the other ones).
This is to ensure consistent indentation for all developers (as long as they use Vim/Neovim).

Used [my own script](https://github.com/DrKJeff16/vim-eof-comment) to do it easily and in bulk.

I assumed these options given your StyLua config:

- `tabstop=2`
- `softtabstop=2`
- `shiftwidth=2`
- `expandtab`
- `autoindent`
- `smartindent`
- `smarttab`
